### PR TITLE
setting: 백엔드 기본 포트 3001로 변경

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -3,6 +3,6 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(process.env.PORT ?? 3000);
+  await app.listen(process.env.PORT ?? 3001);
 }
 void bootstrap();


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #27

## ✅ 작업 내용

- 백엔드 서버 기본 포트를 3000에서 3001로 변경 (`backend/src/main.ts`)

## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?

## 💬 To Reviewers

- 환경 변수 `PORT`가 설정되지 않은 경우 기본값이 3001로 적용됩니다.