### PR TITLE
feat: 맵 중앙에 프로그레스바 UI 구현

### DIFF
--- a/frontend/src/game/scenes/MapScene.ts
+++ b/frontend/src/game/scenes/MapScene.ts
@@ -1,4 +1,5 @@
 import * as Phaser from "phaser";
+import { createProgressBar } from "@/game/ui/createProgressBar";
 
 export class MapScene extends Phaser.Scene {
   private minZoom: number = 0.7;
@@ -107,6 +108,9 @@ export class MapScene extends Phaser.Scene {
       })
       .setOrigin(0.5);
     middleText.setName("mapText");
+
+    // 프로그레스바 생성
+    createProgressBar(this, mapWidth);
 
     // 마우스 휠로 확대/축소
     this.input.on("wheel", this.handleZoom, this);

--- a/frontend/src/game/ui/createProgressBar.ts
+++ b/frontend/src/game/ui/createProgressBar.ts
@@ -1,0 +1,111 @@
+import * as Phaser from "phaser";
+
+/**
+ * 맵 상단 중앙에 프로그레스바를 생성합니다.
+ *
+ * @param scene - Phaser Scene 인스턴스
+ * @param mapWidth - 맵의 너비 (프로그레스바 중앙 정렬에 사용)
+ *
+ * @remarks
+ * - 현재는 2초마다 10%씩 자동 증가하는 임시 로직이 포함되어 있습니다.
+ * - 추후 API 연동 시 자동 증가 로직을 제거하고 외부에서 progress를 제어해야 합니다.
+ */
+export function createProgressBar(scene: Phaser.Scene, mapWidth: number) {
+  const config = {
+    width: 384,
+    height: 24,
+    x: mapWidth / 2 - 192,
+    y: 50,
+    radius: 12,
+    border: 1,
+  };
+
+  let progress = 0;
+
+  // 배경
+  const progressBarBg = scene.add.graphics();
+  progressBarBg.fillStyle(0xe5e7eb, 1);
+  progressBarBg.fillRoundedRect(
+    config.x,
+    config.y,
+    config.width,
+    config.height,
+    config.radius,
+  );
+  progressBarBg.lineStyle(config.border, 0x1f2937, 1);
+  progressBarBg.strokeRoundedRect(
+    config.x,
+    config.y,
+    config.width,
+    config.height,
+    config.radius,
+  );
+
+  const progressBar = scene.add.graphics();
+
+  /**
+   * progrss bar 갱신 함수
+   *  */
+  const updateBar = () => {
+    progressBar.clear();
+
+    const padding = config.border + 2;
+    const fillWidth = ((config.width - padding * 2) * progress) / 100;
+
+    if (fillWidth > 0) {
+      progressBar.fillStyle(0x4ade80, 1);
+      progressBar.fillRoundedRect(
+        config.x + padding,
+        config.y + padding,
+        fillWidth,
+        config.height - padding * 2,
+        config.radius - padding,
+      );
+    }
+  };
+
+  updateBar();
+
+  // 추후 API 동작과 연계할 부분
+  // 현재는 임시로 2초마다 progress 증가
+  scene.time.addEvent({
+    delay: 2000,
+    loop: true,
+    callback: () => {
+      scene.tweens.add({
+        targets: { value: progress },
+        value: Math.min(progress + 10, 100),
+        duration: 300,
+        ease: "Cubic.easeOut",
+        onUpdate: (tween) => {
+          const value = tween.getValue();
+
+          if (typeof value === "number") {
+            progress = value;
+            updateBar();
+          }
+        },
+        onComplete: () => {
+          if (progress >= 100) {
+            scene.time.delayedCall(100, () => {
+              scene.tweens.add({
+                targets: { value: progress },
+                value: 0,
+                duration: 200,
+                ease: "Linear",
+                onUpdate: (tween) => {
+                  const value = tween.getValue();
+
+                  if (typeof value === "number") {
+                    progress = value;
+                    updateBar();
+                  }
+                },
+              });
+            });
+          }
+        },
+      });
+    },
+  });
+}


### PR DESCRIPTION
## 🔗 관련 이슈
close: #26

## ✅ 작업 내용
- 맵 중앙 상단에 프로그레스바 UI 구현 (Phaser Graphics 사용)
- 현재는 API 연동 전 프로그래스바 동작을 확인하기 위해 임시 로직이 추가되어 있음
  - 2초마다 10%씩 자동 증가하는 임시 로직
  - 100% 도달 시 자동 리셋
- Tween 애니메이션으로 부드러운 진행 효과 구현
- `createProgressBar` 함수로 UI 로직 분리하여 MapScene 간소화

## 📸 스크린샷 / 데모 (옵션)

https://github.com/user-attachments/assets/1623faf6-bfc4-45f4-9d7f-846bb3145069





## 💡 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?

## 💬 To Reviewers

### React vs Phaser 구현 방식 선택

프로그레스바를 구현하는데 두 가지 방식을 고려했습니다:

1. **React 컴포넌트 방식**
   - 장점: Tailwind로 쉽고 빠르게 스타일링 가능
   - 단점: 화면(뷰포트) 기준으로 위치가 고정되어, 맵을 줌/팬할 때 프로그레스바가 맵과 따로 움직임

2. **Phaser Graphics 방식** (현재 구현)
   - 장점: 맵 좌표 기준으로 위치가 고정되어 줌/팬 시에도 맵 중앙에 유지됨
   - 단점: CSS보다 스타일링이 번거로움

**결론:** "맵의 정중앙에 위치"라는 요구사항을 만족하기 위해 Phaser Graphics 방식을 선택했습니다. 
줌 인 / 아웃을 통해 맵을 조작할 때, 프로그래스바도 그 위치가 함께 이동해야한다고 생각하여 게임 내 UI라고 판단했습니다.

### 추후 작업 예정

현재는 2초마다 10%씩 자동 증가하는 임시 로직이 포함되어 있습니다. API 연동 시 이 부분을 제거하고 외부에서 progress를 제어하도록 수정할 예정입니다.