### PR TITLE
fix: Socket.IO "Invalid namespace" 오류 수정

### DIFF
--- a/frontend/src/lib/socket.ts
+++ b/frontend/src/lib/socket.ts
@@ -1,12 +1,13 @@
 import { io, Socket } from "socket.io-client";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+const SOCKET_URL =
+  process.env.NEXT_PUBLIC_SOCKET_URL || "http://localhost:8080";
 
 let socket: Socket | null = null;
 
 export const getSocket = (): Socket => {
   if (!socket) {
-    socket = io(API_URL, {
+    socket = io(SOCKET_URL, {
       transports: ["websocket"],
       withCredentials: true,
       autoConnect: false,


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #39

## ✅ 작업 내용

- Socket.IO 연결용 별도 환경변수 `NEXT_PUBLIC_SOCKET_URL` 추가 (`frontend/src/lib/socket.ts`)
- HTTP API(`NEXT_PUBLIC_API_URL`)와 WebSocket 연결 URL을 명시적으로 분리

### 환경변수 설정 예시

| 환경 | `NEXT_PUBLIC_API_URL` | `NEXT_PUBLIC_SOCKET_URL` |
|------|----------------------|-------------------------|
| 로컬 | (미설정) | (미설정) → `http://localhost:8080` |
| 프로덕션 | `https://example.com/api` | `https://example.com` |

## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?

## 💬 To Reviewers

프로덕션 배포 시 `NEXT_PUBLIC_SOCKET_URL` 환경변수 설정이 필요합니다.
