### PR TITLE
feat: 캐릭터 머리 위에 접속 시간 표시 기능 구현

### DIFF
--- a/backend/src/player/player.gateway.ts
+++ b/backend/src/player/player.gateway.ts
@@ -135,7 +135,9 @@ export class PlayerGateway implements OnGatewayConnection, OnGatewayDisconnect {
     return (minutes: number) => {
       // roomId는 추후 방 배정 이후 수정 필요
       const player = this.players.get(client.id);
-      client.to(player!.roomId).emit('timerUpdated', {
+
+      // 같은 방의 모든 유저에게 전송 (자기 자신 포함)
+      this.server.to(player!.roomId).emit('timerUpdated', {
         userId: client.id,
         minutes,
       });

--- a/frontend/src/game/players/Player.ts
+++ b/frontend/src/game/players/Player.ts
@@ -1,10 +1,12 @@
 import { emitEvent } from "../../lib/socket";
+import { formatPlayTime } from "@/utils/timeFormat";
 
 export default class Player {
   private scene: Phaser.Scene;
   private container: Phaser.GameObjects.Container;
   private body: Phaser.Physics.Arcade.Body;
   private maskShape: Phaser.GameObjects.Graphics;
+  private timerText: Phaser.GameObjects.Text;
   private speed: number = 300;
   public id: string;
   private roomId: string;
@@ -48,8 +50,21 @@ export default class Player {
     borderGraphics.lineStyle(4, 0xffffff, 1);
     borderGraphics.strokeCircle(0, FACE_Y_OFFSET, FACE_RADIUS);
 
-    // 5. 컨테이너 추가
-    this.container.add([faceSprite, borderGraphics]);
+    // 5. 접속 시간 표시
+    this.timerText = scene.add
+      .text(0, -35, formatPlayTime(0), {
+        fontSize: "12px",
+        color: "#ffffff",
+        fontFamily: "Arial, sans-serif",
+        fontStyle: "bold",
+      })
+      .setOrigin(0.5);
+
+    this.timerText.setStroke("#000000", 4);
+    this.timerText.setShadow(1, 1, "#000000", 2, false, true);
+
+    // 6. 컨테이너 추가
+    this.container.add([faceSprite, borderGraphics, this.timerText]);
     this.container.setSize(FACE_RADIUS * 2, FACE_RADIUS * 2);
 
     // 6. 물리 엔진 적용
@@ -146,6 +161,13 @@ export default class Player {
       x: this.container.x,
       y: this.container.y,
     };
+  }
+
+  // 접속 시간 업데이트
+  updateTimer(minutes: number) {
+    if (this.timerText) {
+      this.timerText.setText(formatPlayTime(minutes));
+    }
   }
 
   destroy() {

--- a/frontend/src/game/players/RemotePlayer.ts
+++ b/frontend/src/game/players/RemotePlayer.ts
@@ -1,4 +1,5 @@
 import * as Phaser from "phaser";
+import { formatPlayTime } from "@/utils/timeFormat";
 
 export default class RemotePlayer {
   private scene: Phaser.Scene;
@@ -6,6 +7,7 @@ export default class RemotePlayer {
   private body: Phaser.Physics.Arcade.Body;
   private maskShape: Phaser.GameObjects.Graphics;
   private faceSprite: Phaser.GameObjects.Image;
+  private timerText: Phaser.GameObjects.Text;
   public id: string;
 
   constructor(
@@ -56,8 +58,20 @@ export default class RemotePlayer {
       })
       .setOrigin(0.5); */
 
-    // 6. 컨테이너 추가
-    this.container.add([this.faceSprite, borderGraphics]);
+    // 6. 접속 시간 표시
+    this.timerText = scene.add
+      .text(0, -35, formatPlayTime(0), {
+        fontSize: "12px",
+        color: "#ffffff",
+        fontFamily: "Arial, sans-serif",
+      })
+      .setOrigin(0.5);
+
+    this.timerText.setStroke("#000000", 4);
+    this.timerText.setShadow(1, 1, "#000000", 2, false, true);
+
+    // 7. 컨테이너 추가
+    this.container.add([this.faceSprite, borderGraphics, this.timerText]);
     this.container.setSize(FACE_RADIUS * 2, FACE_RADIUS * 2);
 
     // 7. 물리 엔진 적용
@@ -129,6 +143,13 @@ export default class RemotePlayer {
     if (this.container && this.maskShape) {
       this.maskShape.x = this.container.x;
       this.maskShape.y = this.container.y;
+    }
+  }
+
+  // 접속 시간 업데이트
+  updateTimer(minutes: number) {
+    if (this.timerText) {
+      this.timerText.setText(formatPlayTime(minutes));
     }
   }
 

--- a/frontend/src/game/scenes/MapScene.ts
+++ b/frontend/src/game/scenes/MapScene.ts
@@ -233,6 +233,19 @@ export class MapScene extends Phaser.Scene {
         this.otherPlayers.delete(data.userId);
       }
     });
+
+    // 5. 타이머 업데이트
+    socket.on("timerUpdated", (data: { userId: string; minutes: number }) => {
+      const remotePlayer = this.otherPlayers.get(data.userId);
+      if (remotePlayer) {
+        remotePlayer.updateTimer(data.minutes);
+      }
+
+      // 내 플레이어인 경우
+      if (this.player && data.userId === this.player.id) {
+        this.player.updateTimer(data.minutes);
+      }
+    });
   }
 
   addRemotePlayer(data: PlayerData) {

--- a/frontend/src/utils/timeFormat.ts
+++ b/frontend/src/utils/timeFormat.ts
@@ -1,0 +1,22 @@
+/**
+ * 분 단위 시간을 "접속 시간: X시간 Y분" 형식으로 변환
+ * @param minutes - 총 분
+ * @returns 포맷된 시간 문자열
+ */
+export function formatPlayTime(minutes: number): string {
+  let result = "접속 시간: ";
+
+  if (minutes < 60) {
+    result += `${minutes}분`;
+  } else {
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+
+    result += `${hours}시간`;
+    if (mins > 0) {
+      result += ` ${mins}분`;
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## 🔗 관련 이슈
close #38

## ✅ 작업 내용
- **캐릭터 접속 시간 UI 구현**
  - Player, RemotePlayer 클래스에 timerText 추가
  - 캐릭터 머리 위에 접속 시간 표시
- **시간 포맷팅 유틸 함수 추가**
- **소켓 이벤트 처리**
  - MapScene에서 `timerUpdated` 이벤트 수신 및 처리
  - 로컬 플레이어와 리모트 플레이어 모두 타이머 업데이트

- **백엔드 수정**
  - PlayerGateway에서 `client.to()` → `this.server.to()`로 변경
  - 같은 방의 모든 유저(자기 자신 포함)에게 타이머 업데이트 전송

## 📸 스크린샷 / 데모 (옵션)
https://github.com/user-attachments/assets/44c58c31-8ae4-49b3-ba2e-e7e61af498f6



## 💡 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?

## 💬 To Reviewers
- 텍스트 스타일링(폰트, 색상, 크기 등)은 디자인 피드백에 따라 조정 가능합니다
  - 일단은 디자인 고려하지 않고 넣은 상태라서, 의견 주시면 반영하겠습니다