### PR TITLE
fix: 프로덕션 빌드 환경에서 /auth/callback URL 문제 수정

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -50,6 +50,9 @@ import { PointModule } from './point/point.module';
         '/socket.io/*path',
         '/metrics/*path',
       ],
+      serveStaticOptions: {
+        extensions: ['html'],
+      },
     }),
     PlayerModule,
     GithubModule,

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -5,6 +5,7 @@ const isProd = process.env.NODE_ENV === 'production';
 const nextConfig: NextConfig = {
   output: isProd ? 'export' : undefined,
   distDir: isProd ? '../backend/public' : '.next',
+  trailingSlash: true,
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #123

## ✅ 작업 내용
기존 수정(`window.location.replace`)은 개발 환경에서는 동작했지만, **프로덕션 빌드 환경**에서 여전히 문제가 발생하여 추가 수정

### 원인
- Next.js 정적 빌드 시 `auth/callback/` 디렉토리가 생성되지만 `index.html`이 없음
- NestJS ServeStaticModule이 디렉토리 발견 시 `/auth/callback/`로 리다이렉트
- `auth/callback/index.html`이 없어서 루트 `index.html`(메인 페이지)이 반환됨

### 수정 내용
- `frontend/next.config.ts`: `trailingSlash: true` 추가
  - 빌드 시 `auth/callback/index.html` 자동 생성
- `backend/src/app.module.ts`: `serveStaticOptions: { extensions: ['html'] }` 추가

## 💡 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?

## 💬 To Reviewers
이전 PR (#224)에서 `window.location.replace` 수정은 유지하고, 정적 파일 서빙 관련 설정만 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 정적 자산 제공 설정 강화로 HTML 확장자도 안정적으로 서빙되도록 개선
  * 프로덕션 빌드 경로 일관성 확보를 위해 URL 경로 처리 방식 보완 (trailing slash 지원)
  * 인증 콜백 흐름을 클라이언트 라우터 대신 브라우저 네이티브 리디렉션으로 전환하여 호환성 향상

* **문서**
  * 인증 콜백 동작 및 배포 관련 안내 문서 업데이트

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->