### PR TITLE
fix : 타인의 히트맵을 조회가 가능하도록 문제 해결

### DIFF
--- a/backend/src/point/point.controller.ts
+++ b/backend/src/point/point.controller.ts
@@ -1,4 +1,10 @@
-import { Controller, Get, Query, ParseIntPipe, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Query,
+  ParseIntPipe,
+  UseGuards,
+} from '@nestjs/common';
 import { PointService } from './point.service';
 import { PlayerId } from '../auth/player-id.decorator';
 import { JwtGuard } from '../auth/jwt.guard';
@@ -16,6 +22,10 @@ export class PointController {
     @Query('targetPlayerId', ParseIntPipe) targetPlayerId: number,
     @Query('currentTime', ParseDatePipe) currentTime: Date,
   ): Promise<DailyPoint[]> {
-    return this.pointService.getPoints(currentPlayerId, targetPlayerId, currentTime);
+    return this.pointService.getPoints(
+      currentPlayerId,
+      targetPlayerId,
+      currentTime,
+    );
   }
 }

--- a/backend/src/point/point.service.spec.ts
+++ b/backend/src/point/point.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { Repository, DataSource } from 'typeorm';
+import { Repository } from 'typeorm';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { NotFoundException } from '@nestjs/common';
 import { PointService } from './point.service';

--- a/backend/src/point/point.service.ts
+++ b/backend/src/point/point.service.ts
@@ -40,7 +40,9 @@ export class PointService {
     ]);
 
     if (!currentPlayer) {
-      throw new NotFoundException(`Player with ID ${currentPlayerId} not found`);
+      throw new NotFoundException(
+        `Player with ID ${currentPlayerId} not found`,
+      );
     }
     if (!targetPlayer) {
       throw new NotFoundException(`Player with ID ${targetPlayerId} not found`);


### PR DESCRIPTION
## 🔗 관련 이슈

- close #272 

## ✅ 작업 내용

### 1. 타인의 히트맵 조회 기능 추가
- [PointController](cci:2://file:///Users/haechan/Documents/nbc_membership/web19-estrogenquattro/backend/src/point/point.controller.ts:7:0-20:1)에서 `targetPlayerId` 쿼리 파라미터 추가
- 자신뿐만 아니라 다른 플레이어의 포인트(히트맵) 데이터 조회 가능
- `currentPlayerId`와 `targetPlayerId` 존재 여부 검증
- `currentTime` 쿼리 파라미터를 받아 해당 시간 기준 1년치 데이터 조회

### 2. Point 서비스 테스트 코드 작성
- 자신의 포인트 조회 테스트
- 타인의 포인트 조회 테스트
- 1년치 데이터 필터링 테스트
- 존재하지 않는 플레이어 예외 처리 테스트

## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요? (ex. feat : blah blah)
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?

## 💬 To Reviewers

- API 호출 예시: `GET /api/points?targetPlayerId=123&currentTime=2026-01-28T12:00:00.000Z`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 다른 플레이어의 포인트 조회가 가능해졌습니다.
  * 특정 시점을 기준으로 포인트 데이터를 필터링할 수 있습니다.

* **버그 수정 / 동작 변경**
  * 존재하지 않는 플레이어 ID 요청 시 적절한 오류 응답(찾을 수 없음)을 반환하도록 개선되었습니다.

* **테스트**
  * 포인트 조회 기능의 안정성을 검증하는 포괄적인 단위 테스트가 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->