### PR TITLE
fix: 브라우저 다크모드 무시하도록 설정

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -12,6 +12,7 @@
 }
 
 :root {
+  color-scheme: light; /* 브라우저 다크모드 무시, 항상 라이트모드로 표시 */
   --background: #ffffff;
   --foreground: #171717;
 
@@ -85,12 +86,14 @@
   }
 }
 
+/* Dark mode disabled - always use light mode
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
   }
 }
+*/
 
 html,
 body {


### PR DESCRIPTION
## 🔗 관련 이슈
- closes #275

## ✅ 작업 내용
- 다크모드 환경에서 채팅시 채팅 글씨가 회색으로 표기되어 잘 보이지 않는 문제가 존재했습니다. 
- 다크모드에 따른 스타일 변경이 없으므로, 브라우저 다크모드를 무시하도록 설정해두었습니다.

### 변경 전
<img width="416" height="122" alt="image" src="https://github.com/user-attachments/assets/79656ff2-5f37-4c4b-84bc-f02f222df1a7" />

### 변경 후

<img width="451" height="219" alt="image" src="https://github.com/user-attachments/assets/062b6610-92cb-42af-a6f7-5f6ca9b5681f" />

## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요? (ex. feat : blah blah)
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?

## 💬 To Reviewers



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 라이트 모드가 기본 테마로 강제됩니다.
  * 다크 모드 지원이 비활성화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->