### PR TITLE
fix: 채팅 메시지 글자수 백엔드 검증 추가

### DIFF
--- a/backend/src/chat/chat.constants.ts
+++ b/backend/src/chat/chat.constants.ts
@@ -1,0 +1,1 @@
+export const CHAT_MAX_LENGTH = 30;

--- a/backend/src/chat/chat.gateway.spec.ts
+++ b/backend/src/chat/chat.gateway.spec.ts
@@ -1,0 +1,149 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChatGateway } from './chat.gateway';
+import { RoomService } from '../room/room.service';
+import { WsJwtGuard } from '../auth/ws-jwt.guard';
+import { Socket } from 'socket.io';
+import { CHAT_MAX_LENGTH } from './chat.constants';
+
+describe('ChatGateway', () => {
+  let gateway: ChatGateway;
+  let mockRoomService: jest.Mocked<Pick<RoomService, 'getRoomIdBySocketId'>>;
+  let mockWsJwtGuard: jest.Mocked<Pick<WsJwtGuard, 'verifyAndDisconnect'>>;
+  let mockSocket: jest.Mocked<
+    Pick<Socket, 'id' | 'to'> & { to: jest.Mock<{ emit: jest.Mock }> }
+  >;
+  let mockEmit: jest.Mock;
+
+  beforeEach(async () => {
+    mockEmit = jest.fn();
+    mockSocket = {
+      id: 'socket-1',
+      to: jest.fn().mockReturnValue({ emit: mockEmit }),
+    } as unknown as typeof mockSocket;
+
+    mockRoomService = {
+      getRoomIdBySocketId: jest.fn().mockReturnValue('room-1'),
+    };
+
+    mockWsJwtGuard = {
+      verifyAndDisconnect: jest.fn().mockReturnValue(true),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ChatGateway,
+        { provide: RoomService, useValue: mockRoomService },
+        { provide: WsJwtGuard, useValue: mockWsJwtGuard },
+      ],
+    }).compile();
+
+    gateway = module.get<ChatGateway>(ChatGateway);
+  });
+
+  describe('handleMessage', () => {
+    it('30자 이하 메시지는 브로드캐스트된다', () => {
+      // Given: 30자 이하 메시지
+      const message = 'a'.repeat(CHAT_MAX_LENGTH);
+
+      // When: chatting 이벤트 처리
+      gateway.handleMessage({ message }, mockSocket as unknown as Socket);
+
+      // Then: chatted 이벤트 브로드캐스트
+      expect(mockSocket.to).toHaveBeenCalledWith('room-1');
+      expect(mockEmit).toHaveBeenCalledWith('chatted', {
+        userId: 'socket-1',
+        message,
+      });
+    });
+
+    it('30자 초과 메시지는 무시된다', () => {
+      // Given: 31자 이상 메시지
+      const message = 'a'.repeat(CHAT_MAX_LENGTH + 1);
+
+      // When: chatting 이벤트 처리
+      gateway.handleMessage({ message }, mockSocket as unknown as Socket);
+
+      // Then: chatted 이벤트 브로드캐스트 안됨
+      expect(mockEmit).not.toHaveBeenCalled();
+    });
+
+    it('빈 메시지는 무시된다', () => {
+      // Given: 빈 문자열 메시지
+      const message = '';
+
+      // When: chatting 이벤트 처리
+      gateway.handleMessage({ message }, mockSocket as unknown as Socket);
+
+      // Then: chatted 이벤트 브로드캐스트 안됨
+      expect(mockEmit).not.toHaveBeenCalled();
+    });
+
+    it('공백만 있는 메시지는 무시된다', () => {
+      // Given: 공백 문자열 메시지 "   "
+      const message = '   ';
+
+      // When: chatting 이벤트 처리
+      gateway.handleMessage({ message }, mockSocket as unknown as Socket);
+
+      // Then: chatted 이벤트 브로드캐스트 안됨
+      expect(mockEmit).not.toHaveBeenCalled();
+    });
+
+    it('data가 undefined이면 무시된다', () => {
+      // Given: undefined payload
+
+      // When: chatting 이벤트 처리
+      gateway.handleMessage(undefined, mockSocket as unknown as Socket);
+
+      // Then: 에러 없이 무시
+      expect(mockEmit).not.toHaveBeenCalled();
+    });
+
+    it('data.message가 숫자이면 무시된다', () => {
+      // Given: { message: 12345 }
+
+      // When: chatting 이벤트 처리
+      gateway.handleMessage(
+        { message: 12345 },
+        mockSocket as unknown as Socket,
+      );
+
+      // Then: 에러 없이 무시
+      expect(mockEmit).not.toHaveBeenCalled();
+    });
+
+    it('data.message가 null이면 무시된다', () => {
+      // Given: { message: null }
+
+      // When: chatting 이벤트 처리
+      gateway.handleMessage({ message: null }, mockSocket as unknown as Socket);
+
+      // Then: 에러 없이 무시
+      expect(mockEmit).not.toHaveBeenCalled();
+    });
+
+    it('JWT 검증 실패 시 무시된다', () => {
+      // Given: JWT 검증 실패
+      mockWsJwtGuard.verifyAndDisconnect.mockReturnValue(false);
+      const message = 'hello';
+
+      // When: chatting 이벤트 처리
+      gateway.handleMessage({ message }, mockSocket as unknown as Socket);
+
+      // Then: 에러 없이 무시
+      expect(mockEmit).not.toHaveBeenCalled();
+    });
+
+    it('방을 찾을 수 없으면 무시된다', () => {
+      // Given: 방 없음
+      mockRoomService.getRoomIdBySocketId.mockReturnValue(undefined);
+      const message = 'hello';
+
+      // When: chatting 이벤트 처리
+      gateway.handleMessage({ message }, mockSocket as unknown as Socket);
+
+      // Then: 에러 없이 무시
+      expect(mockEmit).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/docs/api/SOCKET_EVENTS.md
+++ b/docs/api/SOCKET_EVENTS.md
@@ -129,12 +129,22 @@ socket.emit('moving', {
 
 ```typescript
 socket.emit('chatting', {
-  message: string  // 채팅 메시지
+  message: string  // 채팅 메시지 (최대 30자)
 });
 ```
 
+**메시지 제한:**
+- 최대 길이: 30자 (원문 기준, trim 전)
+- 공백만 있는 메시지 불가
+
 **서버 동작:**
-- 같은 방에 `chatted` 브로드캐스트
+1. 타입 검증 (`message`가 문자열인지)
+2. 내용 검증 (공백만 있거나 30자 초과 시 무시)
+3. 같은 방에 `chatted` 브로드캐스트
+
+**비정상 메시지 처리:**
+- 검증 실패 시 조용히 무시 (클라이언트에 피드백 없음)
+- 정상 사용자는 클라이언트 검증(HTML maxLength)으로 차단됨
 
 ---
 


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #310

## ✅ 작업 내용

- `chat.constants.ts`: `CHAT_MAX_LENGTH`(30) 상수 정의
- `chat.gateway.ts`: `isChatMessage` 타입 가드 및 검증 로직 추가
  - 공백만 있거나 30자 초과 메시지 무시
- `chat.gateway.spec.ts`: 정상/비정상 케이스 테스트 9개 추가
- `SOCKET_EVENTS.md`: `chatting` 이벤트 메시지 제한 명시

## 🧪 테스트

| 테스트 방식 | 파일 | 테스트 케이스 |
|------------|------|--------------|
| Jest Mock | `chat.gateway.spec.ts` | 30자 이하 메시지 브로드캐스트 |
| Jest Mock | `chat.gateway.spec.ts` | 30자 초과 메시지 무시 |
| Jest Mock | `chat.gateway.spec.ts` | 빈 메시지/공백만 있는 메시지 무시 |
| Jest Mock | `chat.gateway.spec.ts` | 비정상 payload (undefined, 숫자, null) 무시 |

## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?

## 💬 To Reviewers

검증 정책:
- 타입 검증 → 내용 검증 순서로 진행
- 비정상 메시지는 조용히 무시 (클라이언트에 피드백 없음)
- 정상 사용자는 클라이언트 검증(HTML maxLength)으로 이미 차단됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 채팅 메시지에 30자 길이 제한 추가
  * 메시지 입력 검증 강화 (공백, 빈 문자열 처리)

* **Documentation**
  * 채팅 이벤트 API 문서 업데이트 (메시지 제약 조건 명시)

* **Tests**
  * 메시지 검증 로직에 대한 포괄적인 단위 테스트 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->