### PR TITLE
fix : 자정 정산 시 전날 날짜로 포인트 및 히스토리 기록되도록 수정

### DIFF
--- a/backend/src/point/point.service.ts
+++ b/backend/src/point/point.service.ts
@@ -112,7 +112,7 @@ export class PointService {
         }
 
         // 2) 히스토리 기록
-        await this.pointHistoryService.addHistoryWithManager(
+        await this.pointHistoryService.addHistory(
           manager,
           playerId,
           activityType,

--- a/backend/src/pointhistory/point-history.service.spec.ts
+++ b/backend/src/pointhistory/point-history.service.spec.ts
@@ -323,7 +323,7 @@ describe('PointHistoryService', () => {
       expect(result[1].rank).toBe(2);
     });
   });
-  describe('addHistoryWithManager', () => {
+  describe('addHistory', () => {
     it('activityAt이 주어지면 createdAt으로 설정된다 (과거 날짜 기록)', async () => {
       // Given
       const playerId = player1.id;
@@ -335,7 +335,7 @@ describe('PointHistoryService', () => {
       const manager = pointHistoryRepository.manager;
 
       // When
-      const result = await service.addHistoryWithManager(
+      const result = await service.addHistory(
         manager,
         playerId,
         type,
@@ -365,12 +365,7 @@ describe('PointHistoryService', () => {
       const manager = pointHistoryRepository.manager;
 
       // When
-      const result = await service.addHistoryWithManager(
-        manager,
-        playerId,
-        type,
-        amount,
-      );
+      const result = await service.addHistory(manager, playerId, type, amount);
 
       // Then
       expect(result.createdAt).toBeDefined();

--- a/backend/src/pointhistory/point-history.service.ts
+++ b/backend/src/pointhistory/point-history.service.ts
@@ -22,7 +22,7 @@ export class PointHistoryService {
     private readonly focusTimeService: FocusTimeService,
   ) {}
 
-  async addHistoryWithManager(
+  async addHistory(
     manager: EntityManager,
     playerId: number,
     type: PointType,

--- a/backend/src/scheduler/point-settlement.scheduler.ts
+++ b/backend/src/scheduler/point-settlement.scheduler.ts
@@ -62,7 +62,7 @@ export class PointSettlementScheduler {
             PointType.FOCUSED,
             pointCount,
             null,
-            null,
+            '집중 시간 정산',
             end, // 어제 23:59:59로 기록
           );
           this.progressGateway.addProgress(
@@ -128,7 +128,7 @@ export class PointSettlementScheduler {
           PointType.TASK_COMPLETED,
           count,
           null,
-          null,
+          '태스크 완료 정산',
           end, // 어제 23:59:59로 기록
         );
         this.progressGateway.addProgress(nickname, ProgressSource.TASK, count);


### PR DESCRIPTION
## 🔗 관련 이슈

- close : #407

## ✅ 작업 내용

- 태스크 완료, 집중시간 정산 시 24시 자정이 넘어가면 전날 23시59분59초 기준으로 포인트와 내역을 적립하도록 수정했습니다.
- addPoint의 activityAt 필드를 사용해서 정산 후 적립하는 포인트는 activityAt에 UTC 14 59 59 를 넘깁니다.

## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요? (ex. feat : blah blah)
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?

## 💬 To Reviewers



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 활동 시간이 지정된 경우 해당 시간을 기준으로 포인트 일별 범위를 계산하도록 개선해 포인트 반영 정확도가 향상되었습니다.

* **New Features**
  * 포인트 이력에 총점, 저장소, 설명 및 활동 시간이 함께 기록되어 이력의 문맥 정보가 풍부해졌습니다.
  * 정산 기록에 설명 라벨이 포함되어 어떤 정산인지 명확히 확인할 수 있습니다.

* **Tests**
  * 활동 시간 처리와 이력 생성에 대한 단위 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->