### PR TITLE
fix: 일요일 자정 집계는 실시간 랭킹에 반영하지 않도록 수정

### DIFF
--- a/backend/src/scheduler/point-settlement.scheduler.ts
+++ b/backend/src/scheduler/point-settlement.scheduler.ts
@@ -51,6 +51,10 @@ export class PointSettlementScheduler {
       count: focusTimes.length,
     });
 
+    // start는 어제 00:00 KST (UTC로는 전날 15:00)
+    // UTC 6(토) 15시 → KST 0(일) 00시 이므로, UTC 요일이 6이면 KST 일요일임
+    const isSunday = start.getUTCDay() === 6;
+
     for (const focusTime of focusTimes) {
       const pointCount = Math.floor(focusTime.totalFocusSeconds / 1800); // 30분(1800초)당 1포인트
 
@@ -65,15 +69,21 @@ export class PointSettlementScheduler {
             '집중 시간 정산',
             end, // 어제 23:59:59로 기록
           );
-          this.progressGateway.addProgress(
-            focusTime.player.nickname,
-            ProgressSource.FOCUSTIME,
-            pointCount,
-          );
+
+          // 2. 실시간 랭킹 반영 (일요일 정산은 월요일 랭킹에 포함하지 않음)
+          if (!isSunday) {
+            this.progressGateway.addProgress(
+              focusTime.player.nickname,
+              ProgressSource.FOCUSTIME,
+              pointCount,
+            );
+          }
+
           this.logger.log('Awarded FOCUSED points', {
             method: 'settleFocusTimePoints',
             playerId: focusTime.player.id,
             pointCount,
+            skippedRealtime: isSunday,
           });
         } catch (error) {
           const message =
@@ -101,6 +111,9 @@ export class PointSettlementScheduler {
       method: 'settleTaskCompletedPoints',
       count: completedTasks.length,
     });
+
+    // UTC 6(토) 15시 → KST 0(일) 00시
+    const isSunday = start.getUTCDay() === 6;
 
     // 플레이어별 task 개수 집계 - O(n)
     const playerTaskData = new Map<
@@ -131,11 +144,21 @@ export class PointSettlementScheduler {
           '태스크 완료 정산',
           end, // 어제 23:59:59로 기록
         );
-        this.progressGateway.addProgress(nickname, ProgressSource.TASK, count);
+
+        // 2. 실시간 랭킹 반영 (일요일 정산은 월요일 랭킹에 포함하지 않음)
+        if (!isSunday) {
+          this.progressGateway.addProgress(
+            nickname,
+            ProgressSource.TASK,
+            count,
+          );
+        }
+
         this.logger.log('Awarded TASK_COMPLETED points', {
           method: 'settleTaskCompletedPoints',
           playerId,
           count,
+          skippedRealtime: isSunday,
         });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## 🔗 관련 이슈
- close : #454 

## ✅ 작업 내용
- [x] [PointSettlementScheduler](cci:2://file:///Users/haechan/Documents/nbc_membership/web19-estrogenquattro/backend/src/scheduler/point-settlement.scheduler.ts:11:0-172:1)에서 일요일분 정산 시 실시간 랭킹([GlobalState](cci:2://file:///Users/haechan/Documents/nbc_membership/web19-estrogenquattro/backend/src/github/entities/global-state.entity.ts:7:0-23:1)) 반영 스킵 로직 추가
    - `start.getUTCDay() === 6` (KST 일요일 00:00) 조건을 사용하여 월요일 자정에 실행되는 일요일 정산 감지
    - 새 시즌(월요일)의 실시간 랭킹에 지난주 일요일 점수가 합산되는 문제 해결

## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요? (ex. feat : blah blah)
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?

## 💬 To Reviewers
- 월요일 00:00(KST)에만 발생하는 이슈라 로컬 테스트가 어렵습니다.
- `getUTCDay() === 6`은 KST 일요일 00:00이 UTC 토요일 15:00임을 이용한 것입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 일요일의 포인트 정산 시 실시간 진행 상황 업데이트가 스킵되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->