### PR TITLE
fix(leaderboard): stale weekStartAt after season reset

### DIFF
--- a/frontend/src/app/_components/LeaderboardModal/LeaderboardModal.tsx
+++ b/frontend/src/app/_components/LeaderboardModal/LeaderboardModal.tsx
@@ -44,7 +44,7 @@ export default function LeaderboardModal() {
   });
 
   const user = useAuthStore((state) => state.user);
-  const weekendStartAt = useMemo(() => getThisWeekMonday(), []);
+  const weekendStartAt = useMemo(() => getThisWeekMonday(), [isOpen]);
 
   // 리더보드 데이터 (모달이 열릴 때만 API 호출)
   const { ranks, isLoading } = useLeaderboard(

--- a/frontend/src/utils/timeFormat.ts
+++ b/frontend/src/utils/timeFormat.ts
@@ -122,22 +122,26 @@ export function formatSelectedDate(date: Date): string {
 }
 
 /**
- * 이번 주 월요일 00:00:00 (로컬 타임존)을 UTC ISO8601로 반환
- * 리더보드 주간 랭킹 조회 시 사용
+ * 이번 주 월요일 00:00:00 (KST, UTC+9)을 UTC ISO8601로 반환
+ * 리더보드 주간 랭킹 조회 시 사용 (서버 시즌 리셋 기준과 동일하게 KST 고정)
  *
  * 예: 한국 시간 2026-01-29 (수요일) 기준 →
  *     이번주 월요일: 2026-01-27 00:00:00 KST → 2026-01-26T15:00:00.000Z (UTC)
  *
- * @returns 이번 주 월요일 로컬 자정의 UTC ISO8601 문자열
+ * @returns 이번 주 월요일 KST 자정의 UTC ISO8601 문자열
  */
 export function getThisWeekMonday(): string {
   const now = new Date();
-  const day = now.getDay(); // 0(일) ~ 6(토)
-  const diff = day === 0 ? -6 : 1 - day; // 월요일까지의 차이 (일요일이면 -6, 아니면 1-day)
-  const monday = new Date(now);
-  monday.setDate(now.getDate() + diff);
-  monday.setHours(0, 0, 0, 0); // 로컬 타임존 기준 자정
-  return monday.toISOString(); // UTC로 변환
+  const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+  // KST 시각으로 변환하여 요일/날짜 계산
+  const kstNow = new Date(now.getTime() + KST_OFFSET_MS);
+  const day = kstNow.getUTCDay(); // 0(일) ~ 6(토) KST 기준
+  const diff = day === 0 ? -6 : 1 - day;
+  const kstMonday = new Date(kstNow);
+  kstMonday.setUTCDate(kstNow.getUTCDate() + diff);
+  kstMonday.setUTCHours(0, 0, 0, 0);
+  // KST 자정 → UTC로 역변환
+  return new Date(kstMonday.getTime() - KST_OFFSET_MS).toISOString();
 }
 
 /**


### PR DESCRIPTION
Fixes #500

Replace the useMemo(()=>getThisWeekMonday(), []) in LeaderboardModal with a value recalculated each time the modal opens (or move weekendStartAt calculation to backend using KST, ignoring client-supplied value). Also fix getThisWeekMonday() to compute Monday 00:00 KST (UTC+9) instead of local timezone so non-KST users get the correct season boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 리더보드 모달의 주간 데이터가 모달 열기/닫기 시 정확하게 업데이트됩니다.
  * 서버의 시즌 재설정 기준과 일치하는 KST 시간대 기반 주간 시작일 계산을 적용했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->