### PR TITLE
fix: 배포 후 업데이트가 반영되지 않는 캐시 문제 수정

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
+import { ServerResponse } from 'http';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { PlayerModule } from './player/player.module';
@@ -72,7 +73,7 @@ import { BugReportModule } from './bugreport/bug-report.module';
       ],
       serveStaticOptions: {
         extensions: ['html'],
-        setHeaders: (res, path) => {
+        setHeaders: (res: ServerResponse, path: string) => {
           if (path.endsWith('.html')) {
             res.setHeader(
               'Cache-Control',


### PR DESCRIPTION
## 🔗 관련 이슈
- close : #547 

##  문제

배포 후 사용자가 서비스에 접속하면 **이전 버전의 페이지가 표시**되고, `캐시 비우기 및 강력 새로고침(Ctrl+Shift+R)`을 해야만 업데이트된 버전이 반영되는 문제가 지속적으로 발생했습니다.

### 발생 사례
- 스프라이트시트 이미지 변경 후 배포 → 이전 이미지가 계속 표시
- 타일맵 순간이동 기능 추가 후 배포 → 기능이 반영되지 않음
- 서비스 전반 업데이트 후 배포 → 배포 전 상태의 페이지가 표시

## 원인 분석

### 배포 아키텍처

프론트엔드는 Next.js `output: 'export'`로 정적 빌드되어 `backend/public/`에 배치되고, NestJS의 `ServeStaticModule`이 이를 서빙합니다.

Frontend (Next.js static export) → 빌드 결과: backend/public/ (HTML, JS, CSS, 이미지 등) → NestJS ServeStaticModule → Express serve-static → 사용자 브라우저


### 근본 원인: Cache-Control 헤더 미설정

`ServeStaticModule`의 `serveStaticOptions`에 캐시 관련 설정이 전혀 없어, Express `serve-static`의 기본값이 적용되고 있었습니다:

- `maxAge: 0` (기본값)
- `etag: true` (기본값)

#### `max-age=0`이 캐시를 막지 못하는 이유

| 디렉티브 | 의미 |
|---|---|
| `max-age=0` | 즉시 stale → **재검증 필요** (하지만 캐시 저장 자체는 허용) |
| `no-cache` | 캐시 저장하되 **매번 반드시 서버에 재검증** |
| `no-store` | **캐시에 아예 저장하지 않음** |

`max-age=0`은 "캐시하지 마라"가 아니라 "즉시 만료되니 재검증해라"라는 의미입니다. 그러나 다음 상황에서 브라우저가 **재검증을 건너뛰고** 캐시된 응답을 그대로 사용할 수 있습니다:

- 뒤로/앞으로 가기 (bfcache)
- 주소창에 URL 입력 후 엔터
- 일부 브라우저의 공격적 캐시 최적화
- 중간 프록시가 캐시하는 경우

### 2가지 캐시 문제

#### 1. HTML 캐시 → 코드 변경이 반영 안 됨

[배포 전] index.html → /_next/static/chunks/app/page-OLD_HASH.js 참조 
[배포 후] index.html → /_next/static/chunks/app/page-NEW_HASH.js 참조

브라우저가 캐시된 구 index.html 로드 → 구 해시의 JS/CSS 파일 요청 → 이전 버전이 그대로 동작


#### 2. 에셋 캐시 → 이미지/리소스 변경이 반영 안 됨

[public/assets/](cci:7://file:///Users/jun/Desktop/Membership/web19-estrogenquattro/frontend/public/assets:0:0-0:0) 디렉토리의 파일(스프라이트시트, 타일맵 등)은 **파일명에 해시가 포함되지 않은** 정적 에셋입니다:

assets/body_v2.png ← 해시 없음, 파일명 동일 _next/static/app-3f25c05e.js ← 해시 있음, 빌드마다 변경

파일 내용이 바뀌어도 URL이 동일하므로, 브라우저가 캐시된 구 이미지를 그대로 사용합니다.

## ✅ 해결 방법

`ServeStaticModule`의 `serveStaticOptions.setHeaders`에 파일 유형별 `Cache-Control` 헤더를 설정했습니다.

### 캐시 전략

| 파일 유형 | Cache-Control 헤더 | 설명 |
|---|---|---|
| `*.html` | `no-cache, no-store, must-revalidate` | 항상 서버에서 최신 HTML을 받아 JS/CSS 참조 갱신 보장 |
| `_next/static/*` | `public, max-age=31536000, immutable` | 파일명에 해시가 포함되어 있으므로 1년 장기 캐시 (성능 최적화) |
| 기타 에셋 (이미지, 타일맵 등) | `no-cache` | 매 요청 시 서버에 재검증하여 변경분 즉시 반영 |

### 수정 파일

- [backend/src/app.module.ts](cci:7://file:///Users/jun/Desktop/Membership/web19-estrogenquattro/backend/src/app.module.ts:0:0-0:0)

## 기대 효과

- 배포 후 **강력 새로고침 없이도** 업데이트가 즉시 반영됨
- 해시된 에셋(`_next/static/`)은 장기 캐시로 **로딩 성능 향상**
- 이미지/타일맵 등 에셋 변경 시 즉시 반영


## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요? (ex. feat : blah blah)
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?

## 💬 To Reviewers



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **성능 최적화**
  * 정적 자산의 캐싱 헤더 동작을 개선했습니다. HTML 응답은 캐싱을 비활성화하고, 빌드된 정적 파일은 장기(1년) 캐싱 및 불변(immutable)으로 제공되며, 그 외 경로는 캐싱을 비활성화합니다. 이를 통해 최신 HTML 보장과 정적 자산 캐시 활용으로 로드 성능이 향상됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->