### PR TITLE
fix: 타인 프로필 로딩 중 내 프로필 fallback 노출 방지

### DIFF
--- a/frontend/playwright/e2e/issue-574-repro.spec.ts
+++ b/frontend/playwright/e2e/issue-574-repro.spec.ts
@@ -1,0 +1,264 @@
+import {
+  expect,
+  request,
+  test,
+  type Browser,
+  type BrowserContext,
+  type Page,
+} from "@playwright/test";
+import { backendBaseUrl, e2eSecret } from "../constants";
+
+async function seedUserState(
+  browser: Browser,
+  user: { socialId: number; username: string; nickname: string },
+): Promise<BrowserContext> {
+  const apiContext = await request.newContext({
+    baseURL: backendBaseUrl,
+    extraHTTPHeaders: {
+      "x-e2e-secret": e2eSecret,
+    },
+  });
+
+  const loginResponse = await apiContext.post("/auth/test-login", {
+    data: user,
+  });
+  expect(loginResponse.ok()).toBeTruthy();
+
+  const storageState = await apiContext.storageState();
+  await apiContext.dispose();
+
+  return browser.newContext({
+    baseURL: test.info().project.use.baseURL,
+    storageState,
+  });
+}
+
+async function preparePage(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("onboarding_completed", "true");
+    window.localStorage.setItem("i18nextLng", "ko");
+  });
+
+  await page.goto("/");
+  await expect(page.locator("#channel-select-button")).toHaveText(/CH\.\d+/, {
+    timeout: 15_000,
+  });
+  await expect(page.locator("#game-container canvas")).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+async function joinRoom(page: Page, roomNumber: string): Promise<void> {
+  const channelButton = page.locator("#channel-select-button");
+  if ((await channelButton.textContent())?.trim() === `CH.${roomNumber}`) {
+    return;
+  }
+
+  await channelButton.click();
+  const modal = page.locator('[aria-labelledby="channel-select-title"]');
+  await expect(modal).toBeVisible();
+
+  const actionButton = modal
+    .getByText(`CH.${roomNumber}`, { exact: true })
+    .locator("xpath=ancestor::div[2]//button[last()]");
+  await actionButton.click();
+  await expect(modal).toBeHidden();
+  await expect(channelButton).toHaveText(`CH.${roomNumber}`);
+}
+
+async function waitForRemotePlayerCount(page: Page, expectedCount: number) {
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(() => {
+          const el = document.getElementById("game-container");
+          if (!el) return -1;
+
+          const fiberKey = Object.keys(el).find((key) =>
+            key.startsWith("__reactFiber$"),
+          );
+          if (!fiberKey) return -2;
+
+          let fiber: unknown = (el as Record<string, unknown>)[fiberKey];
+          while (
+            fiber &&
+            typeof fiber === "object" &&
+            "type" in fiber &&
+            typeof (fiber as { type: unknown }).type === "string"
+          ) {
+            fiber = (fiber as { return: unknown }).return;
+          }
+
+          const mapFiber = fiber as {
+            memoizedState?: { memoizedState?: { current?: unknown }; next?: unknown };
+          } | null;
+          const game =
+            mapFiber?.memoizedState?.memoizedState &&
+            typeof mapFiber.memoizedState.memoizedState === "object"
+              ? (
+                  mapFiber.memoizedState.memoizedState as {
+                    current?: {
+                      scene?: { scenes?: Array<Record<string, unknown>> };
+                    } | null;
+                  }
+                ).current
+              : null;
+
+          const scene = game?.scene?.scenes?.[0];
+          if (!scene) return -3;
+
+          const otherPlayers = scene.socketManager?.otherPlayers;
+          if (!otherPlayers || typeof otherPlayers.size !== "number") return -4;
+
+          return otherPlayers.size;
+        }),
+      {
+        timeout: 15_000,
+      },
+    )
+    .toBe(expectedCount);
+}
+
+test("issue 574 regression: 다른 사람 프로필 로딩 중 현재 사용자 프로필이 노출되지 않는다", async ({
+  browser,
+  page,
+}) => {
+  const otherContext = await seedUserState(browser, {
+    socialId: 56402,
+    username: "issue-574-other-user",
+    nickname: "Issue 574 Other User",
+  });
+  const otherPage = await otherContext.newPage();
+
+  try {
+    await preparePage(page);
+    await preparePage(otherPage);
+
+    const roomNumber =
+      (await page.locator("#channel-select-button").textContent())
+        ?.trim()
+        .replace("CH.", "") ?? "1";
+
+    await joinRoom(otherPage, roomNumber);
+    await waitForRemotePlayerCount(page, 1);
+
+    await page.route("**/api/github/users/issue-574-other-user", async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 4_000));
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          login: "issue-574-other-user",
+          id: 987654321,
+          avatar_url: "https://avatars.githubusercontent.com/u/987654321?v=4",
+          html_url: "https://github.com/issue-574-other-user",
+          followers: 12,
+          following: 34,
+          name: "Issue 574 Other User",
+          bio: "playwright repro",
+        }),
+      });
+    });
+
+    await page.route(
+      "**/api/github/users/issue-574-other-user/follow-status",
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ isFollowing: false }),
+        });
+      },
+    );
+
+    await page.evaluate(() => {
+      const el = document.getElementById("game-container");
+      if (!el) {
+        throw new Error("game-container not found");
+      }
+
+      const fiberKey = Object.keys(el).find((key) =>
+        key.startsWith("__reactFiber$"),
+      );
+      if (!fiberKey) {
+        throw new Error("react fiber key not found");
+      }
+
+      let fiber: unknown = (el as Record<string, unknown>)[fiberKey];
+      while (
+        fiber &&
+        typeof fiber === "object" &&
+        "type" in fiber &&
+        typeof (fiber as { type: unknown }).type === "string"
+      ) {
+        fiber = (fiber as { return: unknown }).return;
+      }
+
+      const mapFiber = fiber as {
+        memoizedState?: { memoizedState?: { current?: unknown } };
+      } | null;
+      const game = (
+        mapFiber?.memoizedState?.memoizedState as {
+          current?: {
+            canvas: HTMLCanvasElement;
+            scene: { scenes: Array<Record<string, unknown>> };
+          } | null;
+        }
+      )?.current;
+      const scene = game?.scene.scenes[0];
+      const otherPlayers = scene?.socketManager?.otherPlayers;
+
+      if (!otherPlayers || otherPlayers.size === 0) {
+        throw new Error("remote player not found");
+      }
+
+      const remotePlayer = Array.from(otherPlayers.values())[0] as {
+        getContainer: () => {
+          emit: (
+            eventName: string,
+            pointer: { event: { clientX: number; clientY: number } },
+            lx: number,
+            ly: number,
+            eventData: { stopPropagation: () => void },
+          ) => void;
+        };
+      };
+      const canvasRect = game.canvas.getBoundingClientRect();
+      const clientX = canvasRect.left + canvasRect.width * 0.6;
+      const clientY = canvasRect.top + canvasRect.height * 0.6;
+
+      remotePlayer.getContainer().emit(
+        "pointerdown",
+        {
+          event: {
+            clientX,
+            clientY,
+          },
+        },
+        0,
+        0,
+        {
+          stopPropagation() {},
+        },
+      );
+    });
+
+    const modal = page.locator("#user-info-modal");
+    await expect(modal).toBeVisible();
+    await expect(modal.getByText("issue-574-other-user")).toBeVisible();
+
+    await modal.getByRole("button", { name: "프로필", exact: true }).click();
+    await expect(modal.getByText("프로필 로딩 중...")).toBeVisible();
+    await expect(
+      modal.locator('img[src="https://github.com/playwright-user.png"]'),
+    ).toHaveCount(0);
+    await expect(
+      modal.locator('img[src="https://avatars.githubusercontent.com/u/987654321?v=4"]'),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(
+      modal.getByRole("button", { name: "팔로우", exact: true }),
+    ).toBeVisible();
+  } finally {
+    await otherContext.close();
+  }
+});

--- a/frontend/src/app/_components/UserInfoModal/tabs/ProfileTab/ProfileTab.test.tsx
+++ b/frontend/src/app/_components/UserInfoModal/tabs/ProfileTab/ProfileTab.test.tsx
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ProfileTab from "./ProfileTab";
+import { useModalStore } from "@/stores/useModalStore";
+import { useAuthStore } from "@/stores/authStore";
+import { useGithubUser, useFollowStatus } from "@/lib/api/hooks/useGithub";
+import { useFollowMutation } from "@/lib/api/hooks/useFollowMutation";
+
+vi.mock("@/stores/useModalStore");
+vi.mock("@/stores/authStore");
+vi.mock("@/lib/api/hooks/useGithub");
+vi.mock("@/lib/api/hooks/useFollowMutation");
+
+describe("ProfileTab", () => {
+  const logout = vi.fn();
+  const handleFollowToggle = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(useAuthStore).mockImplementation((selector) => {
+      const state = {
+        user: {
+          githubId: "56401",
+          username: "playwright-user",
+          avatarUrl: "https://github.com/playwright-user.png",
+          playerId: 1,
+        },
+        isLoading: false,
+        isAuthenticated: true,
+        fetchUser: vi.fn(),
+        logout,
+      };
+
+      return selector ? selector(state) : state;
+    });
+
+    vi.mocked(useModalStore).mockImplementation((selector) => {
+      const state = {
+        activeModal: "userInfo" as const,
+        userInfoPayload: {
+          playerId: 2,
+          username: "issue-574-other-user",
+        },
+        openModal: vi.fn(),
+        closeModal: vi.fn(),
+        toggleModal: vi.fn(),
+      };
+
+      return selector(state);
+    });
+
+    vi.mocked(useGithubUser).mockReturnValue({
+      user: undefined,
+      isLoading: false,
+      error: null,
+    });
+
+    vi.mocked(useFollowStatus).mockReturnValue({
+      isFollowing: false,
+      isLoading: false,
+      error: null,
+    });
+
+    vi.mocked(useFollowMutation).mockReturnValue({
+      handleFollowToggle,
+      isSubmitting: false,
+    });
+  });
+
+  it("타인 프로필 로딩 중에는 현재 사용자 fallback 대신 로딩 UI만 표시한다", () => {
+    vi.mocked(useGithubUser).mockReturnValue({
+      user: undefined,
+      isLoading: true,
+      error: null,
+    });
+
+    render(<ProfileTab />);
+
+    expect(screen.getByText("프로필 로딩 중...")).toBeInTheDocument();
+    expect(
+      screen.queryByAltText("playwright-user의 프로필"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("playwright-user")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "로그아웃" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("팔로워")).not.toBeInTheDocument();
+  });
+
+  it("내 프로필일 때는 기존 avatar와 로그아웃 버튼을 유지한다", () => {
+    vi.mocked(useModalStore).mockImplementation((selector) => {
+      const state = {
+        activeModal: "userInfo" as const,
+        userInfoPayload: {
+          playerId: 1,
+          username: "playwright-user",
+        },
+        openModal: vi.fn(),
+        closeModal: vi.fn(),
+        toggleModal: vi.fn(),
+      };
+
+      return selector(state);
+    });
+
+    render(<ProfileTab />);
+
+    expect(screen.getByAltText("playwright-user의 프로필")).toHaveAttribute(
+      "src",
+      "https://github.com/playwright-user.png",
+    );
+    expect(
+      screen.getByRole("button", { name: "로그아웃" }),
+    ).toBeInTheDocument();
+  });
+
+  it("타인 프로필 로딩 완료 후에는 대상 사용자 정보와 팔로우 버튼을 표시한다", () => {
+    vi.mocked(useGithubUser).mockReturnValue({
+      user: {
+        login: "issue-574-other-user",
+        id: 987654321,
+        avatar_url: "https://avatars.githubusercontent.com/u/987654321?v=4",
+        html_url: "https://github.com/issue-574-other-user",
+        followers: 12,
+        following: 34,
+        name: "Issue 574 Other User",
+        bio: "playwright repro",
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ProfileTab />);
+
+    expect(
+      screen.getByAltText("issue-574-other-user의 프로필"),
+    ).toHaveAttribute(
+      "src",
+      "https://avatars.githubusercontent.com/u/987654321?v=4",
+    );
+    expect(screen.getByText("issue-574-other-user")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "팔로우" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/_components/UserInfoModal/tabs/ProfileTab/ProfileTab.tsx
+++ b/frontend/src/app/_components/UserInfoModal/tabs/ProfileTab/ProfileTab.tsx
@@ -10,6 +10,7 @@ import { useShallow } from "zustand/react/shallow";
 import { useTranslation } from "react-i18next";
 
 export default function ProfileTab() {
+  const defaultAvatarUrl = "https://avatars.githubusercontent.com/u/0?v=4";
   const { t } = useTranslation("ui");
   const { targetUsername, targetPlayerId } = useModalStore(
     useShallow((state) => ({
@@ -30,20 +31,42 @@ export default function ProfileTab() {
     ? (user?.username ?? targetUsername ?? "")
     : (targetUsername ?? "");
 
-  const { user: githubUser } = useGithubUser(username);
+  const {
+    user: githubUser,
+    isLoading: isLoadingGithubUser,
+    error: githubUserError,
+  } = useGithubUser(username);
   const { isFollowing, isLoading: isLoadingFollowStatus } = useFollowStatus(
     !isOwnProfile ? username : "",
   );
   const { handleFollowToggle, isSubmitting } = useFollowMutation(username);
 
+  const isOtherProfileLoading =
+    !isOwnProfile && isLoadingGithubUser && !githubUser;
+
+  if (isOtherProfileLoading) {
+    return (
+      <div className="space-y-6 px-4 pt-20 pb-4">
+        <div className="flex flex-col items-center gap-4">
+          <div className="h-24 w-24 animate-pulse rounded-full bg-amber-200 shadow-[4px_4px_0px_0px_rgba(0,0,0,0.15)]" />
+          <div className="h-6 w-40 animate-pulse bg-amber-200" />
+          <div className="text-sm font-bold text-amber-700">
+            {t(($) => $.userInfoModal.loading)}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   const profileData = {
-    avatarUrl:
-      githubUser?.avatar_url ??
-      user?.avatarUrl ??
-      "https://avatars.githubusercontent.com/u/0?v=4",
-    githubUsername: githubUser?.login ?? username ?? "Unknown",
-    followers: githubUser?.followers ?? 0,
-    following: githubUser?.following ?? 0,
+    avatarUrl: isOwnProfile
+      ? (githubUser?.avatar_url ?? user?.avatarUrl ?? defaultAvatarUrl)
+      : (githubUser?.avatar_url ?? defaultAvatarUrl),
+    githubUsername:
+      githubUser?.login ?? username ?? targetUsername ?? "Unknown",
+    followers: githubUser?.followers ?? (isOwnProfile ? 0 : "--"),
+    following: githubUser?.following ?? (isOwnProfile ? 0 : "--"),
+    isUnavailable: !isOwnProfile && !githubUser && !!githubUserError,
   };
 
   return (
@@ -65,7 +88,11 @@ export default function ProfileTab() {
             href={`https://github.com/${profileData.githubUsername}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="relative cursor-pointer text-lg font-bold text-amber-900 transition-colors hover:text-amber-700"
+            className={`relative text-lg font-bold text-amber-900 transition-colors ${
+              profileData.isUnavailable
+                ? "cursor-default opacity-70"
+                : "cursor-pointer hover:text-amber-700"
+            }`}
           >
             {profileData.githubUsername}
             <span className="absolute top-1/2 right-0 translate-x-[calc(100%+8px)] -translate-y-1/2">
@@ -101,7 +128,9 @@ export default function ProfileTab() {
         <div className="flex justify-center">
           <Button
             onClick={() => handleFollowToggle(isFollowing)}
-            disabled={isLoadingFollowStatus || isSubmitting}
+            disabled={
+              isLoadingFollowStatus || isSubmitting || profileData.isUnavailable
+            }
             className={`flex w-full cursor-pointer items-center justify-center gap-2 rounded-none border-2 py-2 font-bold transition-all active:translate-x-0.5 active:translate-y-0.5 active:shadow-none disabled:cursor-not-allowed disabled:opacity-50 ${
               isFollowing
                 ? "border-red-700 bg-red-600 text-white shadow-[4px_4px_0px_0px_#7f1d1d] hover:bg-red-700"


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #574

## ✅ 작업 내용

- `ProfileTab`에서 타인 프로필 로딩 중 현재 로그인 사용자 avatar를 fallback으로 사용하지 않도록 수정했습니다.
- 타인 프로필 조회 중에는 안전한 loading UI만 표시하고, GitHub 사용자 정보가 준비된 뒤에만 실제 프로필 정보를 렌더링하도록 분기했습니다.
- `ProfileTab` 단위 테스트를 추가해 타인 프로필 로딩 상태와 내 프로필 유지 동작을 보호했습니다.
- Playwright 이슈 재현 스펙을 수정 후 회귀 테스트로 전환했습니다.

## 🧪 테스트 (옵션)

| 테스트 방식 | 파일 | 테스트 케이스 |
|------------|------|--------------|
| Vitest | `ProfileTab.test.tsx` | 타인 프로필 로딩 중 현재 사용자 avatar 미노출, 내 프로필 유지, 타인 프로필 로딩 완료 렌더링 |
| Playwright | `issue-574-repro.spec.ts` | 타인 프로필 로딩 중 현재 사용자 프로필 미노출 회귀 검증 |

## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?

## 💬 To Reviewers

- 타인 프로필 로딩 중 placeholder를 먼저 보여주고, GitHub 사용자 정보가 준비된 뒤 실제 프로필 정보를 렌더링하는 방향입니다.
- follow 버튼은 타인 프로필 데이터가 준비된 뒤에만 의미가 있으므로, 조회 실패 상태에서는 비활성화되도록 처리했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * GitHub 이슈 템플릿 추가로 버그 보고 및 기능 요청 프로세스 개선
  * 게임 맵에 조명 효과(Candle) 추가
  * 프로필 로딩 상태 표시 및 사용 불가 상태 처리 개선

* **Documentation**
  * 개발 환경 설정 및 E2E 테스트 실행 가이드 추가
  * 환경 변수 및 통합 테스트 범위 문서화

* **Tests**
  * 통합 테스트 및 E2E 테스트 인프라 구축

<!-- end of auto-generated comment: release notes by coderabbit.ai -->