### PR TITLE
feat: 주간 순위표 username GitHub 프로필 링크 추가

### DIFF
--- a/frontend/src/app/_components/GuestbookModal/GuestbookEntryCard.tsx
+++ b/frontend/src/app/_components/GuestbookModal/GuestbookEntryCard.tsx
@@ -1,7 +1,7 @@
 import { Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { formatRelativeTime } from "@/utils/timeFormat";
-import { getGithubAvatarUrl } from "@/utils/github";
+import { getGithubAvatarUrl, getGithubProfileUrl } from "@/utils/github";
 import type { GuestbookEntry } from "./types";
 
 interface GuestbookEntryCardProps {
@@ -29,7 +29,7 @@ export default function GuestbookEntryCard({
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
             <a
-              href={`https://github.com/${nickname}`}
+              href={getGithubProfileUrl(nickname)}
               target="_blank"
               rel="noopener noreferrer"
               className="text-base font-bold text-amber-900 transition-colors hover:text-amber-700"

--- a/frontend/src/app/_components/LeaderboardModal/PlayerRow.test.tsx
+++ b/frontend/src/app/_components/LeaderboardModal/PlayerRow.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import PlayerRow from "./PlayerRow";
 import { POINT_TYPES } from "@/lib/api";
+import { getGithubProfileUrl } from "@/utils/github";
 import type { LeaderboardPlayer } from "./types";
 
 const mockPlayer: LeaderboardPlayer = {
@@ -17,6 +18,31 @@ describe("PlayerRow", () => {
     render(<PlayerRow player={mockPlayer} />);
 
     expect(screen.getByText("testuser")).toBeInTheDocument();
+  });
+
+  it("플레이어 이름은 GitHub 프로필 링크로 렌더링된다", () => {
+    render(<PlayerRow player={mockPlayer} />);
+
+    const link = screen.getByRole("link", { name: "testuser" });
+    expect(link).toHaveAttribute("href", getGithubProfileUrl("testuser"));
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("프로필 이미지와 점수는 링크가 아니다", () => {
+    render(<PlayerRow player={mockPlayer} />);
+
+    expect(screen.getByAltText("testuser").closest("a")).toBeNull();
+    expect(screen.getByText("100").closest("a")).toBeNull();
+  });
+
+  it("사용자명이 비어 있으면 링크 없이 텍스트만 렌더링된다", () => {
+    render(<PlayerRow player={{ ...mockPlayer, username: "   " }} />);
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(
+      screen.getByText((_, element) => element?.textContent === "   "),
+    ).toBeInTheDocument();
   });
 
   it("1~3등은 No.N 형식으로 표시한다", () => {

--- a/frontend/src/app/_components/LeaderboardModal/PlayerRow.tsx
+++ b/frontend/src/app/_components/LeaderboardModal/PlayerRow.tsx
@@ -1,6 +1,7 @@
 import type { LeaderboardPlayer } from "./types";
 import { getRankTextColor, getRankDisplay, formatSecondsToHMS } from "./utils";
 import { POINT_TYPES, type PointType } from "@/lib/api";
+import { getGithubProfileUrl } from "@/utils/github";
 
 interface PlayerRowProps {
   player: LeaderboardPlayer;
@@ -17,6 +18,10 @@ export default function PlayerRow({
 }: PlayerRowProps) {
   const rankTextColor = getRankTextColor(player.rank);
   const rankDisplay = getRankDisplay(player.rank);
+  const trimmedUsername = player.username.trim();
+  const githubProfileUrl = trimmedUsername
+    ? getGithubProfileUrl(trimmedUsername)
+    : null;
 
   // 집중 시간 탭일 때는 시간 형식으로 표시
   const displayValue =
@@ -53,9 +58,20 @@ export default function PlayerRow({
           </div>
         )}
       </div>
-      <span className="text-center font-medium text-amber-900">
-        {player.username}
-      </span>
+      {githubProfileUrl ? (
+        <a
+          href={githubProfileUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block text-center font-medium text-amber-900 underline-offset-2 transition-colors hover:text-amber-700 hover:underline focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-amber-700 focus-visible:outline-offset-2"
+        >
+          {trimmedUsername}
+        </a>
+      ) : (
+        <span className="text-center font-medium text-amber-900">
+          {player.username}
+        </span>
+      )}
       <span className="text-center font-bold text-amber-900">
         {displayValue}
       </span>

--- a/frontend/src/app/_components/UserInfoModal/tabs/ProfileTab/ProfileTab.tsx
+++ b/frontend/src/app/_components/UserInfoModal/tabs/ProfileTab/ProfileTab.tsx
@@ -8,6 +8,7 @@ import { useGithubUser, useFollowStatus } from "@/lib/api/hooks/useGithub";
 import { useFollowMutation } from "@/lib/api/hooks/useFollowMutation";
 import { useShallow } from "zustand/react/shallow";
 import { useTranslation } from "react-i18next";
+import { getGithubProfileUrl } from "@/utils/github";
 
 export default function ProfileTab() {
   const { t } = useTranslation("ui");
@@ -62,7 +63,7 @@ export default function ProfileTab() {
 
         <div className="flex items-center justify-center">
           <a
-            href={`https://github.com/${profileData.githubUsername}`}
+            href={getGithubProfileUrl(profileData.githubUsername)}
             target="_blank"
             rel="noopener noreferrer"
             className="relative cursor-pointer text-lg font-bold text-amber-900 transition-colors hover:text-amber-700"

--- a/frontend/src/utils/github.test.ts
+++ b/frontend/src/utils/github.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { getGithubAvatarUrl, getGithubProfileUrl } from "./github";
+
+describe("github utils", () => {
+  it("GitHub 아바타 URL을 생성한다", () => {
+    expect(getGithubAvatarUrl("octocat")).toBe("https://github.com/octocat.png");
+  });
+
+  it("GitHub 프로필 URL을 생성한다", () => {
+    expect(getGithubProfileUrl("octocat")).toBe("https://github.com/octocat");
+  });
+});

--- a/frontend/src/utils/github.ts
+++ b/frontend/src/utils/github.ts
@@ -8,3 +8,13 @@
 export function getGithubAvatarUrl(username: string): string {
   return `https://github.com/${username}.png`;
 }
+
+/**
+ * GitHub 사용자명으로 프로필 URL 생성
+ *
+ * @param username - GitHub 사용자명
+ * @returns GitHub 프로필 URL
+ */
+export function getGithubProfileUrl(username: string): string {
+  return `https://github.com/${username}`;
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #576

## ✅ 작업 내용

- `LeaderboardModal/PlayerRow.tsx`에서 `username`만 GitHub 프로필 외부 링크로 동작하도록 변경했습니다.
- `avatar`, `rank`, `points/time/count` 컬럼은 비클릭 영역으로 유지했습니다.
- `frontend/src/utils/github.ts`에 `getGithubProfileUrl` 유틸을 추가하고, 프로필 탭/방명록/리더보드가 같은 URL 생성 규칙을 사용하도록 맞췄습니다.
- `PlayerRow`와 GitHub URL 유틸 테스트를 추가해 링크/비링크 경계와 예외 케이스를 고정했습니다.

## 🧪 테스트 (옵션)

| 테스트 방식 | 파일 | 테스트 케이스 |
|------------|------|--------------|
| Vitest | `src/app/_components/LeaderboardModal/PlayerRow.test.tsx` | username 링크 렌더링, 새 탭 속성, avatar/score 비링크, blank username 안전 처리 |
| Vitest | `src/utils/github.test.ts` | GitHub avatar/profile URL 생성 규칙 |
| Vitest | `src/app/_components/LeaderboardModal/LeaderboardModal.test.tsx` | 리더보드 모달 탭 전환/접근성/기존 동작 회귀 |
| Browser | local verification | username 클릭/Enter 새 탭 생성, avatar/rank/score 비클릭, 내 순위 링크 동작 |

실행 명령:
- `cd frontend && pnpm test -- --run src/app/_components/LeaderboardModal/PlayerRow.test.tsx src/utils/github.test.ts src/app/_components/LeaderboardModal/LeaderboardModal.test.tsx`

## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?

## 💬 To Reviewers

- UX 결정은 `username만 링크`입니다. avatar와 점수 컬럼은 일부러 비클릭으로 유지했습니다.
- 공용 컴포넌트 추출까지는 가지 않고, 최소 변경으로 `getGithubProfileUrl` 유틸만 추가했습니다.
- 이슈 본문 체크리스트는 테스트와 브라우저 검증 기준으로 모두 확인 후 체크했습니다.