### PR TITLE
feat: city 모든 stage에 촛불 이펙트 적용

### DIFF
--- a/frontend/public/assets/tilemaps/city/city_stage1.json
+++ b/frontend/public/assets/tilemaps/city/city_stage1.json
@@ -3267,9 +3267,44 @@
          "visible":true,
          "x":0,
          "y":0
+                }, 
+        {
+         "draworder":"topdown",
+         "id":4,
+         "name":"Lights",
+         "objects":[
+                {
+                 "height":0,
+                 "id":850,
+                 "name":"",
+                 "point":true,
+                 "rotation":0,
+                 "type":"candle",
+                 "visible":true,
+                 "width":0,
+                 "x":2231.33333333333,
+                 "y":2555.33333333333
+                }, 
+                {
+                 "height":0,
+                 "id":851,
+                 "name":"",
+                 "point":true,
+                 "rotation":0,
+                 "type":"candle",
+                 "visible":true,
+                 "width":0,
+                 "x":664,
+                 "y":2194
+                }],
+         "opacity":1,
+         "type":"objectgroup",
+         "visible":true,
+         "x":0,
+         "y":0
         }],
- "nextlayerid":4,
- "nextobjectid":850,
+ "nextlayerid":5,
+ "nextobjectid":852,
  "orientation":"orthogonal",
  "renderorder":"right-down",
  "tiledversion":"1.11.2",

--- a/frontend/public/assets/tilemaps/city/city_stage2.json
+++ b/frontend/public/assets/tilemaps/city/city_stage2.json
@@ -5865,9 +5865,44 @@
          "visible":true,
          "x":0,
          "y":0
+                }, 
+        {
+         "draworder":"topdown",
+         "id":4,
+         "name":"Lights",
+         "objects":[
+                {
+                 "height":0,
+                 "id":1082,
+                 "name":"",
+                 "point":true,
+                 "rotation":0,
+                 "type":"candle",
+                 "visible":true,
+                 "width":0,
+                 "x":2231.33333333333,
+                 "y":2555.33333333333
+                }, 
+                {
+                 "height":0,
+                 "id":1083,
+                 "name":"",
+                 "point":true,
+                 "rotation":0,
+                 "type":"candle",
+                 "visible":true,
+                 "width":0,
+                 "x":664,
+                 "y":2194
+                }],
+         "opacity":1,
+         "type":"objectgroup",
+         "visible":true,
+         "x":0,
+         "y":0
         }],
- "nextlayerid":4,
- "nextobjectid":1082,
+ "nextlayerid":5,
+ "nextobjectid":1084,
  "orientation":"orthogonal",
  "renderorder":"right-down",
  "tiledversion":"1.11.2",

--- a/frontend/public/assets/tilemaps/city/city_stage3.json
+++ b/frontend/public/assets/tilemaps/city/city_stage3.json
@@ -5832,9 +5832,44 @@
          "visible":true,
          "x":0,
          "y":0
+                }, 
+        {
+         "draworder":"topdown",
+         "id":4,
+         "name":"Lights",
+         "objects":[
+                {
+                 "height":0,
+                 "id":1161,
+                 "name":"",
+                 "point":true,
+                 "rotation":0,
+                 "type":"candle",
+                 "visible":true,
+                 "width":0,
+                 "x":2231.33333333333,
+                 "y":2555.33333333333
+                }, 
+                {
+                 "height":0,
+                 "id":1162,
+                 "name":"",
+                 "point":true,
+                 "rotation":0,
+                 "type":"candle",
+                 "visible":true,
+                 "width":0,
+                 "x":664,
+                 "y":2194
+                }],
+         "opacity":1,
+         "type":"objectgroup",
+         "visible":true,
+         "x":0,
+         "y":0
         }],
- "nextlayerid":4,
- "nextobjectid":1161,
+ "nextlayerid":5,
+ "nextobjectid":1163,
  "orientation":"orthogonal",
  "renderorder":"right-down",
  "tiledversion":"1.11.2",

--- a/frontend/public/assets/tilemaps/city/city_stage4.json
+++ b/frontend/public/assets/tilemaps/city/city_stage4.json
@@ -5986,9 +5986,44 @@
          "visible":true,
          "x":0,
          "y":0
+                }, 
+        {
+         "draworder":"topdown",
+         "id":4,
+         "name":"Lights",
+         "objects":[
+                {
+                 "height":0,
+                 "id":1321,
+                 "name":"",
+                 "point":true,
+                 "rotation":0,
+                 "type":"candle",
+                 "visible":true,
+                 "width":0,
+                 "x":2231.33333333333,
+                 "y":2555.33333333333
+                }, 
+                {
+                 "height":0,
+                 "id":1322,
+                 "name":"",
+                 "point":true,
+                 "rotation":0,
+                 "type":"candle",
+                 "visible":true,
+                 "width":0,
+                 "x":664,
+                 "y":2194
+                }],
+         "opacity":1,
+         "type":"objectgroup",
+         "visible":true,
+         "x":0,
+         "y":0
         }],
- "nextlayerid":4,
- "nextobjectid":1321,
+ "nextlayerid":5,
+ "nextobjectid":1323,
  "orientation":"orthogonal",
  "renderorder":"right-down",
  "tiledversion":"1.11.2",

--- a/frontend/test/unit/city-tilemaps.spec.ts
+++ b/frontend/test/unit/city-tilemaps.spec.ts
@@ -1,0 +1,76 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+type TilemapLayer = {
+  id: number;
+  name: string;
+  type: string;
+  objects?: Array<{
+    id: number;
+    type?: string;
+    class?: string;
+    x?: number;
+    y?: number;
+  }>;
+};
+
+type TilemapData = {
+  layers: TilemapLayer[];
+};
+
+const expectedCollisionObjectCounts = {
+  1: 285,
+  2: 521,
+  3: 518,
+  4: 532,
+  5: 454,
+} as const;
+
+function loadCityStage(stage: keyof typeof expectedCollisionObjectCounts): TilemapData {
+  const filePath = path.resolve(
+    process.cwd(),
+    "public/assets/tilemaps/city",
+    `city_stage${stage}.json`,
+  );
+
+  return JSON.parse(fs.readFileSync(filePath, "utf8")) as TilemapData;
+}
+
+describe("city tilemap fixture", () => {
+  it("city stage1~5 모두 Lights object layer와 candle 포인트 2개를 가진다", () => {
+    for (const stage of [1, 2, 3, 4, 5] as const) {
+      const tilemap = loadCityStage(stage);
+      const lightsLayer = tilemap.layers.find(
+        (layer) => layer.name === "Lights" && layer.type === "objectgroup",
+      );
+
+      expect(lightsLayer, `stage${stage} Lights layer`).toBeDefined();
+
+      const candleObjects =
+        lightsLayer?.objects?.filter(
+          (object) => (object.class ?? object.type) === "candle",
+        ) ?? [];
+
+      expect(candleObjects, `stage${stage} candle objects`).toHaveLength(2);
+      candleObjects.forEach((object) => {
+        expect(object.x).toEqual(expect.any(Number));
+        expect(object.y).toEqual(expect.any(Number));
+      });
+    }
+  });
+
+  it("city stage1~5의 Collisions 레이어 구조는 유지된다", () => {
+    for (const stage of [1, 2, 3, 4, 5] as const) {
+      const tilemap = loadCityStage(stage);
+      const collisionsLayer = tilemap.layers.find(
+        (layer) => layer.name === "Collisions" && layer.type === "objectgroup",
+      );
+
+      expect(collisionsLayer, `stage${stage} Collisions layer`).toBeDefined();
+      expect(collisionsLayer?.objects).toHaveLength(
+        expectedCollisionObjectCounts[stage],
+      );
+    }
+  });
+});

--- a/frontend/test/unit/light-effect.spec.ts
+++ b/frontend/test/unit/light-effect.spec.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { candleInstances, CandleMock } = vi.hoisted(() => {
+  const instances: Array<{
+    destroy: ReturnType<typeof vi.fn>;
+    scene: unknown;
+    context: unknown;
+  }> = [];
+
+  const ctor = vi.fn().mockImplementation((scene, context) => {
+    const instance = {
+      destroy: vi.fn(),
+      scene,
+      context,
+    };
+    instances.push(instance);
+    return instance;
+  });
+
+  return {
+    candleInstances: instances,
+    CandleMock: ctor,
+  };
+});
+
+vi.mock("phaser", () => ({}));
+
+vi.mock("@/game/effects/lights/Candle", () => ({
+  Candle: CandleMock,
+}));
+
+import LightEffect from "@/game/effects/LightEffect";
+
+describe("LightEffect", () => {
+  beforeEach(() => {
+    CandleMock.mockClear();
+    candleInstances.length = 0;
+  });
+
+  it("Lights 레이어의 candle type/class만 worldScale 기준 좌표로 생성한다", () => {
+    const scene = {
+      events: {
+        on: vi.fn(),
+        once: vi.fn(),
+      },
+      cache: {
+        tilemap: {
+          get: vi.fn(() => ({
+            data: {
+              layers: [
+                {
+                  name: "Lights",
+                  type: "objectgroup",
+                  objects: [
+                    { type: "candle", x: 664, y: 2194 },
+                    { class: "candle", x: 2231.33333333333, y: 2555.33333333333 },
+                    { type: "torch", x: 1, y: 2 },
+                    { type: "candle", x: 10 },
+                  ],
+                },
+              ],
+            },
+          })),
+        },
+      },
+    };
+
+    const lightEffect = new LightEffect(scene as never, 4);
+
+    lightEffect.create("tilemap1");
+
+    expect(CandleMock).toHaveBeenCalledTimes(2);
+    expect(CandleMock).toHaveBeenNthCalledWith(1, scene, {
+      class: "candle",
+      x: 166,
+      y: 548.5,
+    });
+    expect(CandleMock).toHaveBeenNthCalledWith(2, scene, {
+      class: "candle",
+      x: 557.8333333333325,
+      y: 638.8333333333325,
+    });
+  });
+
+  it("Lights 레이어가 없으면 light를 생성하지 않는다", () => {
+    const scene = {
+      events: {
+        on: vi.fn(),
+        once: vi.fn(),
+      },
+      cache: {
+        tilemap: {
+          get: vi.fn(() => ({
+            data: {
+              layers: [{ name: "Collisions", type: "objectgroup", objects: [] }],
+            },
+          })),
+        },
+      },
+    };
+
+    const lightEffect = new LightEffect(scene as never, 4);
+    lightEffect.create("tilemap1");
+
+    expect(CandleMock).not.toHaveBeenCalled();
+  });
+
+  it("create를 다시 호출하면 기존 light를 먼저 destroy한 뒤 새로 생성한다", () => {
+    const cache = {
+      tilemap: {
+        get: vi
+          .fn()
+          .mockReturnValueOnce({
+            data: {
+              layers: [
+                {
+                  name: "Lights",
+                  type: "objectgroup",
+                  objects: [{ type: "candle", x: 400, y: 800 }],
+                },
+              ],
+            },
+          })
+          .mockReturnValueOnce({
+            data: {
+              layers: [
+                {
+                  name: "Lights",
+                  type: "objectgroup",
+                  objects: [{ type: "candle", x: 800, y: 1200 }],
+                },
+              ],
+            },
+          }),
+      },
+    };
+
+    const scene = {
+      events: {
+        on: vi.fn(),
+        once: vi.fn(),
+      },
+      cache,
+    };
+
+    const lightEffect = new LightEffect(scene as never, 4);
+
+    lightEffect.create("tilemap1");
+    const firstInstance = candleInstances[0];
+
+    lightEffect.create("tilemap1");
+
+    expect(firstInstance.destroy).toHaveBeenCalledTimes(1);
+    expect(CandleMock).toHaveBeenCalledTimes(2);
+    expect(CandleMock).toHaveBeenNthCalledWith(2, scene, {
+      class: "candle",
+      x: 200,
+      y: 300,
+    });
+  });
+});


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #575

## ✅ 작업 내용

- city `stage1~4` 타일맵에 `Lights` object layer와 `candle` 포인트 2개씩 추가
- 기존 `stage5` candle 배치를 기준선으로 유지해 city `stage1~5` 전체에서 동일 규칙 적용
- `LightEffect` 파싱/cleanup 동작을 고정하는 단위 테스트 추가
- city tilemap fixture가 `Lights` 레이어와 candle 포인트를 유지하는지 검증하는 테스트 추가

## 🧪 테스트 (옵션)

| 테스트 방식 | 파일 | 테스트 케이스 |
|------------|------|--------------|
| Unit | `frontend/test/unit/light-effect.spec.ts` | `Lights` 레이어 candle 파싱, `worldScale` 좌표 변환, 재호출 시 기존 light cleanup |
| Unit | `frontend/test/unit/city-tilemaps.spec.ts` | city `stage1~5`의 `Lights` 레이어/candle 포인트 존재, `Collisions` object count 유지 |

실행 명령:
- `cd frontend && pnpm exec vitest run test/unit/light-effect.spec.ts test/unit/city-tilemaps.spec.ts`

## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (예: `feature/login` -> `develop`)

## 스크린샷

![SCR-20260319-tfbk](https://github.com/user-attachments/assets/6eb0147d-4d95-40a3-8649-9e3f06c87594)
![SCR-20260319-tfjr](https://github.com/user-attachments/assets/37b6a076-292f-4870-93f2-8948285bb949)
![SCR-20260319-tgjh-2](https://github.com/user-attachments/assets/717081ad-0ae1-4044-a8a3-bcc84d200cd2)
![SCR-20260319-tgvi](https://github.com/user-attachments/assets/b37f62c8-4b66-44ce-a7ac-bd5a9024bbd8)


## 💬 To Reviewers
- 이번 변경은 런타임 리팩터링 없이 자산 보강 + 회귀 테스트 추가로 범위를 제한했습니다.
- 수동 검증에서는 stage 전환 시 이펙트 위치와 잔상 여부를 한 번 더 확인해주시면 됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 도시 맵(스테이지 1-4)에 조명 효과 레이어 추가

* **테스트**
  * 도시 맵 검증 테스트 추가
  * 조명 효과 기능 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->