### PR TITLE
refactor: 게임 엔진 지연 로딩으로 초기 진입 성능 개선

### DIFF
--- a/frontend/src/_components/GameCanvas.tsx
+++ b/frontend/src/_components/GameCanvas.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import * as Phaser from "phaser";
+import { gameConfig } from "@/game/config";
+import type { PlayerInfoResponse } from "@/lib/api/pet";
+import type { User } from "@/stores/authStore";
+
+interface GameCanvasProps {
+  user: User;
+  player: PlayerInfoResponse;
+}
+
+export default function GameCanvas({ user, player }: GameCanvasProps) {
+  const gameRef = useRef<Phaser.Game | null>(null);
+
+  useEffect(() => {
+    if (gameRef.current) return;
+
+    gameRef.current = new Phaser.Game(gameConfig);
+
+    const petImage = player.equippedPet?.actualImgUrl || null;
+    gameRef.current.registry.set("user", { ...user, petImage });
+  }, [user, player]);
+
+  useEffect(() => {
+    return () => {
+      if (gameRef.current) {
+        gameRef.current.destroy(true);
+        gameRef.current = null;
+      }
+    };
+  }, []);
+
+  return <div id="game-container" className="h-full w-full" />;
+}

--- a/frontend/src/_components/Map.tsx
+++ b/frontend/src/_components/Map.tsx
@@ -1,50 +1,41 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import * as Phaser from "phaser";
+import { useEffect } from "react";
+import dynamic from "next/dynamic";
 import { useQuery } from "@tanstack/react-query";
 import { petApi } from "@/lib/api/pet";
-import { gameConfig } from "@/game/config";
 import { useAuthStore } from "@/stores/authStore";
+import { Loading } from "@/_components/ui/loading";
+
+const GameCanvas = dynamic(() => import("./GameCanvas"), {
+  ssr: false,
+  loading: () => <GameLoading />,
+});
+
+function GameLoading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loading size="lg" />
+    </div>
+  );
+}
 
 export default function Map() {
-  const gameRef = useRef<Phaser.Game | null>(null);
   const user = useAuthStore((state) => state.user);
 
-  // 플레이어 정보 (장착 펫 포함) 미리 가져오기
   const { data: player } = useQuery({
     queryKey: ["player", "info", user?.playerId],
     queryFn: () => petApi.getPlayer(user!.playerId),
-    enabled: !!user?.playerId, // 유저 정보가 있을 때만 실행
+    enabled: !!user?.playerId,
   });
 
   useEffect(() => {
-    // 이미 게임이 생성되어 있으면 return
-    if (gameRef.current) return;
-
-    // 유저 정보와 플레이어 정보(펫)가 모두 준비되어야 게임 시작
-    if (!user || !player) return;
-
-    // Phaser 게임 생성
-    gameRef.current = new Phaser.Game(gameConfig);
-
-    // 로그인된 유저 정보 바탕으로 펫 정보를 Phaser Registry에 저장
-    const petImage = player.equippedPet?.actualImgUrl || null;
-
-    gameRef.current.registry.set("user", {
-      ...user,
-      petImage, // 장착된 펫 이미지 URL (없으면 null)
-    });
-  }, [user, player]);
-
-  useEffect(() => {
-    return () => {
-      if (gameRef.current) {
-        gameRef.current.destroy(true);
-        gameRef.current = null;
-      }
-    };
+    void import("./GameCanvas");
   }, []);
 
-  return <div id="game-container" className="h-full w-full" />;
+  if (!user || !player) {
+    return <GameLoading />;
+  }
+
+  return <GameCanvas user={user} player={player} />;
 }

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -4,7 +4,7 @@ import { Analytics } from "@/lib/analytics";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
 
-interface User {
+export interface User {
   githubId: string;
   username: string;
   avatarUrl: string;


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 이슈 있으면 #번호, 없으면 비워두거나 "데모 세션 피드백" 명시 -->

## ✅ 작업 내용

**문제**
- Phaser(≈1.16MB)가 `page → Map` 정적 import로 초기 번들에 포함
- 이로 인해 인증(`/auth/me`)·플레이어 데이터 요청과 첫 렌더가 **엔진 다운로드+파싱 뒤로 직렬 지연** (Network 탭 실측: Phaser 청크 로드 후 `/auth/me` 시작)

**해결 — 데이터와 엔진 렌더 분리**
- `Map.tsx`: Phaser·gameConfig import 제거, `useQuery`(데이터)는 유지 → 엔진과 무관하게 즉시 실행
- `GameCanvas.tsx`(신규): Phaser 로직을 이동, `user`/`player`를 props로 받음 → `dynamic(ssr:false)`로 지연 로딩
- 엔진 청크를 데이터 요청과 **병렬 preload**(`void import`)해 게임 시작 지연 방지
- `authStore.ts`: `User` 타입 export

**효과 (측정)**
- Before(prod, Lighthouse 5회 중앙값): 초기 로드 JS **2,624KB**(Phaser 44%) / TBT **600ms** / LCP **4.5s**
- After: [측정 예정 — 재배포 후]

## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요? (`perf: ...`)
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`perf/phaser-lazy-load`)

## 💬 To Reviewers

- `Map` 전체를 dynamic import하지 않은 이유: Map 안 `useQuery`까지 lazy 청크에 갇혀 데이터 요청이 오히려 늦어짐 → 데이터/렌더 분리로 해결
- Phaser는 `window`/canvas 의존이라 SSR 불가 → `ssr:false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 게임 화면이 별도 캔버스 컴포넌트로 분리되어, 더 안정적으로 로드되고 렌더링됩니다.
  * 로딩 중에는 대기 화면이 표시되어 초기 진입 경험이 개선되었습니다.

* **Bug Fixes**
  * 화면 전환이나 언마운트 시 게임이 올바르게 정리되도록 개선해, 중복 생성 및 잔여 상태 문제를 줄였습니다.
  * 사용자 및 장착 펫 정보가 게임에 더 일관되게 반영되도록 처리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->